### PR TITLE
Fix dependency constraints

### DIFF
--- a/validates_formatting_of.gemspec
+++ b/validates_formatting_of.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = ValidatesFormattingOf::VERSION
 
-  gem.add_dependency "rails", ">= 3.0.0"
+  gem.add_dependency "rails", "~> 3.0"
 
-  gem.add_development_dependency "rake", "0.9.2"
-  gem.add_development_dependency "rspec", "2.7.0"
-  gem.add_development_dependency "supermodel", "0.1.6"
+  gem.add_development_dependency "rake"
+  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "supermodel"
 end


### PR DESCRIPTION
There's no good reason to specify precise development dependency constraints.

Also, it's better to use ~> than >= for runtime dependencies. See [this blog post by @wycats](http://yehudakatz.com/2010/08/21/using-considered-harmful-or-whats-wrong-with/) for a good explanation of why.

Would you mind merging this pull request and pushing a new gem version? Thanks!
