### PR TITLE
Hyphens in the host/domain names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.4.2
+* Dropped support for Ruby 1.8.7
+* Dropped support for REE
+* Updated email regex so that hosts/domains cannot start or end with hyphens.
+
 ## v0.4.0
 
 * Email and phone validations more flexible.

--- a/README.markdown
+++ b/README.markdown
@@ -4,6 +4,13 @@
 
 The `validates_formatting_of` gem adds several convenient methods to validate things such as emails, urls, and phone numbers in a Rails application.
 
+# Unsupported versions
+
+Please note that this module takes advantage of regular expression features which are newer features in Ruby. Because of this, certain versions are not supported:
+
+* 1.8.7
+* Ruby Enterprise Edition (REE)
+
 # Installation
 
 To install `validates_formatting_of`, add the following to your `Gemfile`:

--- a/lib/validates_formatting_of/validating_methods.rb
+++ b/lib/validates_formatting_of/validating_methods.rb
@@ -3,7 +3,7 @@ module ValidatesFormattingOf
 
     # This method is very close to allowing what is specified in RFC 5322 and RFC 5321
     def email
-      /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i
+      /\A([^@\s]+)@((?:(?!-)[-a-z0-9]+(?<!-)\.)+[a-z]{2,})\Z/i
     end
 
     # Taken from Ryan Bates' screencast on extracting gems. Works extremely well. Thanks Ryan!

--- a/spec/validates_formatting_of/model_additions_spec.rb
+++ b/spec/validates_formatting_of/model_additions_spec.rb
@@ -14,6 +14,9 @@ describe ValidatesFormattingOf::ModelAdditions do
       Email.new(:email => "this__???{}|__should@be-valid.com").should be_valid
       Email.new(:email => "visitorservices@vmfa.museum").should be_valid
       Email.new(:email => "info@samoa.travel").should be_valid
+      Email.new(:email => "info@-samoa.travel").should_not be_valid
+      Email.new(:email => "info@samoa-.travel").should_not be_valid
+      Email.new(:email => "info@123-samoa.travel").should be_valid
     end
   end
 


### PR DESCRIPTION
Added a zero-width negative look-ahead and look-behind assertion to the email regex so that the host and domain names can't start or end with a hyphen.
